### PR TITLE
Helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run build && mocha --compilers js:babel-register",
+    "test": "npm run build && npm run test:built",
+    "test:built": "mocha --compilers js:babel-register",
     "clean": "rm -rf dist",
     "build": "npm run clean && babel src --out-dir lib",
+    "build:watch": "npm run clean && babel src --out-dir lib --watch",
     "lint": "eslint src",
     "prepublish": "npm run lint && npm test"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.3.0",
     "estraverse-fb": "^1.3.1",
+    "form-data": "^1.0.0-rc4",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "estraverse-fb": "^1.3.1",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "whatwg-fetch": "^0.11.0"
   },
   "dependencies": {
-    "eventemitter2": "^1.0.0"
+    "eventemitter2": "^1.0.0",
+    "merge": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.3.0",
     "estraverse-fb": "^1.3.1",
-    "form-data": "^1.0.0-rc4",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",

--- a/src/client.js
+++ b/src/client.js
@@ -104,4 +104,29 @@ export default class Client {
   on(event, cb) {
     this.eventEmitter.on(event, cb);
   }
+
+  /* ---- HELPERS ---- */
+  get(path, options) {
+
+  }
+
+  post(path, body, options) {
+
+  }
+
+  put(path, body, options) {
+
+  }
+
+  path(path, body, options) {
+
+  }
+
+  delete(path, options) {
+
+  }
+
+  upload(path, file, options) {
+
+  }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -92,6 +92,7 @@ export default class Client {
 
     let fetchPromise;
     if (request && !onStartError) {
+      console.log(request);
       fetchPromise = fetch(request)
         .then(response => {
           const mutatedResponse = this._callOnSuccesses(request, response);
@@ -168,7 +169,17 @@ export default class Client {
     return this.fetch(path, _options);
   }
 
-  upload(path, file, options) {
-    return this.fetch(path, options);
+  upload(path, input, options) {
+    const _options = options || {};
+    _options.method = 'post';
+
+    const data = new FormData();
+    let i;
+    for (i = 0; i < input.files.length; i++) {
+      data.append('files[]', input.files[i]);
+    }
+
+    _options.body = data;
+    return this.fetch(path, _options);
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -141,7 +141,9 @@ export default class Client {
   }
 
   delete(path, options) {
-    return this.fetch(path, options);
+    const _options = options || {};
+    _options.method = 'delete';
+    return this.fetch(path, _options);
   }
 
   upload(path, file, options) {

--- a/src/client.js
+++ b/src/client.js
@@ -11,6 +11,20 @@ const _defaults = {
       'Content-Type': 'application/json',
     },
   },
+  put: {
+    method: 'post',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  },
+  patch: {
+    method: 'post',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  },
 };
 
 export default class Client {
@@ -133,11 +147,19 @@ export default class Client {
   }
 
   put(path, body, options) {
-    return this.fetch(path, options);
+    let _options = { ...this.defaults.put };
+    _options.body = JSON.stringify(body);
+    _options = merge.recursive(true, _options, options);
+    _options.method = 'put';
+    return this.fetch(path, _options);
   }
 
-  path(path, body, options) {
-    return this.fetch(path, options);
+  patch(path, body, options) {
+    let _options = { ...this.defaults.patch };
+    _options.body = JSON.stringify(body);
+    _options = merge.recursive(true, _options, options);
+    _options.method = 'patch';
+    return this.fetch(path, _options);
   }
 
   delete(path, options) {

--- a/src/client.js
+++ b/src/client.js
@@ -92,7 +92,6 @@ export default class Client {
 
     let fetchPromise;
     if (request && !onStartError) {
-      console.log(request);
       fetchPromise = fetch(request)
         .then(response => {
           const mutatedResponse = this._callOnSuccesses(request, response);

--- a/src/client.js
+++ b/src/client.js
@@ -1,10 +1,22 @@
 import EventEmitter2 from 'eventemitter2';
 import * as events from './events';
 import MiddlewareError from './middleware-error';
+import merge from 'merge';
+
+const _defaults = {
+  post: {
+    method: 'post',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  },
+};
 
 export default class Client {
   constructor(defaults) {
-    this.defaults = defaults || {};
+    this.defaults = merge.recursive(true, _defaults, defaults);
+
     if (this.defaults.url) {
       this.defaults.sep = this.defaults.url[this.defaults.url.length - 1] === '/' ? '' : '/';
     }
@@ -113,7 +125,11 @@ export default class Client {
   }
 
   post(path, body, options) {
-    return this.fetch(path, options);
+    let _options = { ...this.defaults.post };
+    _options.body = JSON.stringify(body);
+    _options = merge.recursive(true, _options, options);
+    _options.method = 'post';
+    return this.fetch(path, _options);
   }
 
   put(path, body, options) {

--- a/src/client.js
+++ b/src/client.js
@@ -107,26 +107,26 @@ export default class Client {
 
   /* ---- HELPERS ---- */
   get(path, options) {
-
+    return this.fetch(path, options);
   }
 
   post(path, body, options) {
-
+    return this.fetch(path, options);
   }
 
   put(path, body, options) {
-
+    return this.fetch(path, options);
   }
 
   path(path, body, options) {
-
+    return this.fetch(path, options);
   }
 
   delete(path, options) {
-
+    return this.fetch(path, options);
   }
 
   upload(path, file, options) {
-
+    return this.fetch(path, options);
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -177,18 +177,4 @@ export default class Client {
     _options.method = 'delete';
     return this.fetch(path, _options);
   }
-
-  upload(path, input, options) {
-    const _options = options || {};
-    _options.method = 'post';
-
-    const data = new FormData();
-    let i;
-    for (i = 0; i < input.files.length; i++) {
-      data.append('files[]', input.files[i]);
-    }
-
-    _options.body = data;
-    return this.fetch(path, _options);
-  }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -4,7 +4,11 @@ import MiddlewareError from './middleware-error';
 
 export default class Client {
   constructor(defaults) {
-    this.defaults = defaults;
+    this.defaults = defaults || {};
+    if (this.defaults.url) {
+      this.defaults.sep = this.defaults.url[this.defaults.url.length - 1] === '/' ? '' : '/';
+    }
+
     this.eventEmitter = new EventEmitter2();
     this._middleware = [];
   }
@@ -45,7 +49,12 @@ export default class Client {
   }
 
   fetch(path, options) {
-    let request = new Request(path, options);
+    let fullPath = path;
+    if (this.defaults && this.defaults.url) {
+      fullPath = `${this.defaults.url}${this.defaults.sep}${path}`;
+    }
+
+    let request = new Request(fullPath, options);
     this.eventEmitter.emit(events.REQUEST_START, request);
 
     let onStartError;

--- a/src/client.js
+++ b/src/client.js
@@ -107,7 +107,9 @@ export default class Client {
 
   /* ---- HELPERS ---- */
   get(path, options) {
-    return this.fetch(path, options);
+    const _options = options || {};
+    _options.method = 'get';
+    return this.fetch(path, _options);
   }
 
   post(path, body, options) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,3 +1,4 @@
 export const REQUEST_START = 'REQUEST_START';
 export const REQUEST_SUCCESS = 'REQUEST_SUCCESS';
 export const REQUEST_FAIL = 'REQUEST_FAIL';
+export const REQUEST_ERROR = 'REQUEST_ERROR';

--- a/test/client.js
+++ b/test/client.js
@@ -13,7 +13,7 @@ import MiddlewareError from '../lib/middleware-error';
 
 import EventEmitter2 from 'eventemitter2';
 import * as events from '../lib/events';
-import { Request, fetch } from 'whatwg-fetch';
+import { Request } from 'whatwg-fetch';
 GLOBAL.Request = Request;
 
 describe('client', () => {

--- a/test/client.js
+++ b/test/client.js
@@ -346,7 +346,24 @@ describe('client', () => {
       });
     });
 
-    it('calls get() with method=\'get\' in options');
+    it('calls fetch() with method=\'get\' in options when calling get()', () => {
+      const myClient = new Client({ url: 'http://something.com' });
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.get('test').then(() => {
+        expect(myClient.fetch.args[0][1].method).to.equal('get');
+      });
+    });
+
+    it('calls fetch() with passed options when calling get()', () => {
+      const myClient = new Client({ url: 'http://something.com' });
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.get('test', { something: 'test' }).then(() => {
+        expect(myClient.fetch.args[0][1].something).to.equal('test');
+      });
+    });
+
     it('calls post setting headers, method, body');
     it('calls delete with method=\'delete\' in options');
     it('calls patch with headers, method, body');

--- a/test/client.js
+++ b/test/client.js
@@ -378,7 +378,25 @@ describe('client', () => {
       });
     });
 
-    it('overrides defaults when calling post with options');
+    it('overrides defaults when calling post with options', () => {
+      const myClient = new Client({ url: 'http://something.com' });
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.post(
+        'test',
+        { something: 'test' },
+        { method: 'notallowed', headers: { Accept: 'test' }, anotherThing: 'cool' }
+      )
+        .then(() => {
+          expect(myClient.fetch.args[0][1].method).to.equal('post');
+          expect(myClient.fetch.args[0][1].headers).to.deep.equal({
+            Accept: 'test',
+            'Content-Type': 'application/json',
+          });
+          expect(myClient.fetch.args[0][1].anotherThing).to.equal('cool');
+        });
+    });
+
     it('uses post defaults from main defaults object');
     it('calls delete with method=\'delete\' in options');
     it('calls patch with headers, method, body');

--- a/test/client.js
+++ b/test/client.js
@@ -416,7 +416,16 @@ describe('client', () => {
         });
     });
 
-    it('calls delete with method=\'delete\' in options');
+    it('calls delete with method=\'delete\' in options', () => {
+      const myClient = new Client({ url: 'http://something.com' });
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.delete('test').then(() => {
+        expect(myClient.fetch.args[0][1].method).to.equal('delete');
+        expect(myClient.fetch.args[0][0]).to.equal('test');
+      });
+    });
+
     it('calls patch with headers, method, body');
     it('calls put with headers, method, body');
     it('calls upload with headers, method, body');

--- a/test/client.js
+++ b/test/client.js
@@ -364,7 +364,22 @@ describe('client', () => {
       });
     });
 
-    it('calls post setting headers, method, body');
+    it('calls fetch setting headers, method, body when calling post', () => {
+      const myClient = new Client({ url: 'http://something.com' });
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.post('test', { something: 'test' }).then(() => {
+        expect(myClient.fetch.args[0][1].method).to.equal('post');
+        expect(myClient.fetch.args[0][1].headers).to.deep.equal({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        });
+        expect(myClient.fetch.args[0][1].body).to.equal(JSON.stringify({ something: 'test' }));
+      });
+    });
+
+    it('overrides defaults when calling post with options');
+    it('uses post defaults from main defaults object');
     it('calls delete with method=\'delete\' in options');
     it('calls patch with headers, method, body');
     it('calls put with headers, method, body');

--- a/test/client.js
+++ b/test/client.js
@@ -326,7 +326,26 @@ describe('client', () => {
   });
 
   describe('helpers & defaults', () => {
-    it('prepends default url to fetch path');
+    it('prepends default url to fetch path', () => {
+      GLOBAL.fetch = sinon.spy(() => Promise.resolve('test'));
+      const myClient = new Client({ url: 'http://something.com/' });
+
+      return myClient.fetch('test').then(() => {
+        expect(GLOBAL.fetch.args[0][0]).to.be.instanceof(Request);
+        expect(GLOBAL.fetch.args[0][0].url).to.equal('http://something.com/test');
+      });
+    });
+
+    it('includes slash in url if omitted', () => {
+      GLOBAL.fetch = sinon.spy(() => Promise.resolve('test'));
+      const myClient = new Client({ url: 'http://something.com' });
+
+      return myClient.fetch('test').then(() => {
+        expect(GLOBAL.fetch.args[0][0]).to.be.instanceof(Request);
+        expect(GLOBAL.fetch.args[0][0].url).to.equal('http://something.com/test');
+      });
+    });
+
     it('calls get() with method=\'get\' in options');
     it('calls post setting headers, method, body');
     it('calls delete with method=\'delete\' in options');

--- a/test/client.js
+++ b/test/client.js
@@ -16,9 +16,7 @@ import * as events from '../lib/events';
 
 // polyfills
 import { Request, Response } from 'whatwg-fetch';
-import FormData from 'form-data';
 GLOBAL.Request = Request;
-GLOBAL.FormData = FormData;
 
 describe('client', () => {
   it('should not fail to instantiate', () => {
@@ -500,23 +498,6 @@ describe('client', () => {
           });
           expect(myClient.fetch.args[0][1].anotherThing).to.equal('cool');
         });
-    });
-
-    it('calls upload with headers, method, body', () => {
-      FormData.prototype.append = sinon.spy();
-      const myClient = new Client({ url: 'http://something.com' });
-      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
-
-      const input = {
-        files: ['test', 'hey'],
-      };
-
-      return myClient.upload('test', input).then(() => {
-        expect(myClient.fetch.args[0][1].method).to.equal('post');
-        expect(FormData.prototype.append).to.be.calledTwice;
-        expect(FormData.prototype.append).to.have.been.calledWith('files[]', 'test');
-        expect(FormData.prototype.append).to.have.been.calledWith('files[]', 'hey');
-      });
     });
   });
 });

--- a/test/client.js
+++ b/test/client.js
@@ -397,7 +397,25 @@ describe('client', () => {
         });
     });
 
-    it('uses post defaults from main defaults object');
+    it('uses post defaults from main defaults object', () => {
+      const myClient = new Client({
+        url: 'http://something.com',
+        post: { method: 'notallowed', headers: { Accept: 'test' }, anotherThing: 'cool' },
+      });
+
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.post('test', { something: 'test' })
+        .then(() => {
+          expect(myClient.fetch.args[0][1].method).to.equal('post');
+          expect(myClient.fetch.args[0][1].headers).to.deep.equal({
+            Accept: 'test',
+            'Content-Type': 'application/json',
+          });
+          expect(myClient.fetch.args[0][1].anotherThing).to.equal('cool');
+        });
+    });
+
     it('calls delete with method=\'delete\' in options');
     it('calls patch with headers, method, body');
     it('calls put with headers, method, body');

--- a/test/client.js
+++ b/test/client.js
@@ -426,8 +426,44 @@ describe('client', () => {
       });
     });
 
-    it('calls patch with headers, method, body');
-    it('calls put with headers, method, body');
+    it('calls patch with headers, method, body', () => {
+      const myClient = new Client({
+        url: 'http://something.com',
+        put: { method: 'notallowed', headers: { Accept: 'test' }, anotherThing: 'cool' },
+      });
+
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.put('test', { something: 'test' })
+        .then(() => {
+          expect(myClient.fetch.args[0][1].method).to.equal('put');
+          expect(myClient.fetch.args[0][1].headers).to.deep.equal({
+            Accept: 'test',
+            'Content-Type': 'application/json',
+          });
+          expect(myClient.fetch.args[0][1].anotherThing).to.equal('cool');
+        });
+    });
+
+    it('calls put with headers, method, body', () => {
+      const myClient = new Client({
+        url: 'http://something.com',
+        patch: { method: 'notallowed', headers: { Accept: 'test' }, anotherThing: 'cool' },
+      });
+
+      myClient.fetch = sinon.spy(() => Promise.resolve('test'));
+
+      return myClient.patch('test', { something: 'test' })
+        .then(() => {
+          expect(myClient.fetch.args[0][1].method).to.equal('patch');
+          expect(myClient.fetch.args[0][1].headers).to.deep.equal({
+            Accept: 'test',
+            'Content-Type': 'application/json',
+          });
+          expect(myClient.fetch.args[0][1].anotherThing).to.equal('cool');
+        });
+    });
+
     it('calls upload with headers, method, body');
   });
 });

--- a/test/client.js
+++ b/test/client.js
@@ -324,4 +324,14 @@ describe('client', () => {
       });
     });
   });
+
+  describe('helpers & defaults', () => {
+    it('prepends default url to fetch path');
+    it('calls get() with method=\'get\' in options');
+    it('calls post setting headers, method, body');
+    it('calls delete with method=\'delete\' in options');
+    it('calls patch with headers, method, body');
+    it('calls put with headers, method, body');
+    it('calls upload with headers, method, body');
+  });
 });


### PR DESCRIPTION
For #6.

On the fence about the structure of defaults. I kind of wanted to allow put, post, patch, get, etc to have their own default headers, but now that I think about it, they'll probably always want to be the same.

It's also probably not great to assume in patch/put/post that the body should be encoded as JSON. I was thinking about taking out the json encoding and just adding it to the json decoding middleware. So that middleware will use the onStart() to encode the body as JSON and onSuccess() to decode the response JSON. As long as we check the Content-Type of the request for json then this should be fine.
