### PR TITLE
Gracefully handle JSON.parse error

### DIFF
--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -1,6 +1,10 @@
 import { AUTH_EXPIRED, AUTH_FAILED } from '../events';
 
 const isExpired = (token) => {
+  if (typeof token !== 'string') {
+    return false;
+  }
+
   const tokenPayload = token.substring(
       token.indexOf('.') + 1,
       token.indexOf('.', token.indexOf('.') + 1)
@@ -8,12 +12,12 @@ const isExpired = (token) => {
 
   try {
     const decodedPayload = JSON.parse(atob(tokenPayload));
-  } catch (error) {
-    return true;
-  }
 
-  if (decodedPayload.exp < (new Date().getTime() / 1000)) {
-    return true;
+    if (decodedPayload.exp < (new Date().getTime() / 1000)) {
+      return true;
+    }
+  } catch (error) {
+    console.trace(error);
   }
 
   return false;

--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -1,16 +1,12 @@
 import { AUTH_EXPIRED, AUTH_FAILED } from '../events';
 
 const isExpired = (token) => {
-  if (typeof token !== 'string') {
-    return false;
-  }
-
-  const tokenPayload = token.substring(
+  try {
+    const tokenPayload = token.substring(
       token.indexOf('.') + 1,
       token.indexOf('.', token.indexOf('.') + 1)
-  );
+    );
 
-  try {
     const decodedPayload = JSON.parse(atob(tokenPayload));
 
     if (decodedPayload.exp < (new Date().getTime() / 1000)) {

--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -17,7 +17,7 @@ const isExpired = (token) => {
       return true;
     }
   } catch (error) {
-    // Swallow JSON or base64 decoding errors and emit auth failure event instead
+    // Swallow any JSON or base64 decoding errors
     return false;
   }
 

--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -17,7 +17,8 @@ const isExpired = (token) => {
       return true;
     }
   } catch (error) {
-    console.trace(error);
+    // Swallow JSON or base64 decoding errors and emit auth failure event instead
+    return false;
   }
 
   return false;

--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -5,7 +5,12 @@ const isExpired = (token) => {
       token.indexOf('.') + 1,
       token.indexOf('.', token.indexOf('.') + 1)
   );
-  const decodedPayload = JSON.parse(atob(tokenPayload));
+
+  try {
+    const decodedPayload = JSON.parse(atob(tokenPayload));
+  } catch (error) {
+    return true;
+  }
 
   if (decodedPayload.exp < (new Date().getTime() / 1000)) {
     return true;

--- a/test/plugins/jwt-test.js
+++ b/test/plugins/jwt-test.js
@@ -104,6 +104,48 @@ describe('jwt-plugin', () => {
     });
   });
 
+  it('emits AUTH_FAILED event if request 401s and token is null', () => {
+    const response = new Response("{ body: 'content' }", { status: 401 });
+    GLOBAL.fetch = sinon.spy(() => Promise.resolve(response));
+    const token = null;
+    const request = new Request();
+    const client = new Client();
+    const failedSpy = sinon.spy();
+    const expiredSpy = sinon.spy();
+    client.on(AUTH_EXPIRED, expiredSpy);
+    client.on(AUTH_FAILED, failedSpy);
+    client.addPlugin(jwtPlugin);
+    client.setJwtTokenGetter(() => token);
+
+    return client.post(request).then(() => {
+      expect(failedSpy).to.have.been.called;
+      expect(expiredSpy).not.to.have.been.called;
+      expect(failedSpy.args[0][0]).to.equal(request);
+      expect(failedSpy.args[0][1]).to.equal(response);
+    });
+  });
+
+  it('emits AUTH_FAILED event if request 401s and token is invalid', () => {
+    const response = new Response("{ body: 'content' }", { status: 401 });
+    GLOBAL.fetch = sinon.spy(() => Promise.resolve(response));
+    const token = '{}';
+    const request = new Request();
+    const client = new Client();
+    const failedSpy = sinon.spy();
+    const expiredSpy = sinon.spy();
+    client.on(AUTH_EXPIRED, expiredSpy);
+    client.on(AUTH_FAILED, failedSpy);
+    client.addPlugin(jwtPlugin);
+    client.setJwtTokenGetter(() => token);
+
+    return client.post(request).then(() => {
+      expect(failedSpy).to.have.been.called;
+      expect(expiredSpy).not.to.have.been.called;
+      expect(failedSpy.args[0][0]).to.equal(request);
+      expect(failedSpy.args[0][1]).to.equal(response);
+    });
+  });
+
   it('does not emit either custom event if request fails with non-401', () => {
     const response = new Response("{ body: 'content' }", { status: 500 });
     GLOBAL.fetch = sinon.spy(() => Promise.resolve(response));

--- a/test/plugins/jwt-test.js
+++ b/test/plugins/jwt-test.js
@@ -125,10 +125,10 @@ describe('jwt-plugin', () => {
     });
   });
 
-  it('emits AUTH_FAILED event if request 401s and token is invalid', () => {
+  it('emits AUTH_FAILED event if request 401s and decoded token is invalid JSON', () => {
     const response = new Response("{ body: 'content' }", { status: 401 });
     GLOBAL.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = '{}';
+    const token = 'foo';
     const request = new Request();
     const client = new Client();
     const failedSpy = sinon.spy();


### PR DESCRIPTION
When JSON.parse fails, it throws a `SyntaxError` exception, which causes any promises further up the chain (for example, our api middleware) to reject.