### PR TITLE
don't reuse requests in oauth plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run clean && babel src --out-dir lib",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint src",
-    "prepublish": "npm run lint && npm test && npm run build"
+    "prepublishOnly": "npm run lint && npm test && npm run build"
   },
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
     "sinon": "~1.17.3",
     "sinon-chai": "~2.8.0",
     "urlsearchparams": "~0.1.1",
-    "whatwg-fetch": "~0.11.0"
+    "whatwg-fetch": "2.0.4"
   },
   "dependencies": {
     "@babel/runtime": "7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/fetch-client",
-  "version": "2.0.0",
+  "version": "2.0.1-rc1",
   "description": "A wrapper for fetch to make things more easier",
   "main": "lib/index.js",
   "directories": {

--- a/src/client.js
+++ b/src/client.js
@@ -59,8 +59,8 @@ export default class Client {
     return this._callPluginMethod('onSuccess', 1, false, request, response);
   }
 
-  _callOnCompletes(request, response) {
-    return this._callPluginMethod('onComplete', 1, false, request, response);
+  _callOnCompletes(request, response, clonedRequest) {
+    return this._callPluginMethod('onComplete', 1, false, request, response, clonedRequest);
   }
 
   _callOnFails(request, response) {
@@ -103,6 +103,7 @@ export default class Client {
     }
 
     this.eventEmitter.emit(events.REQUEST_START, request);
+    const clonedRequest = request.clone();
     try {
       request = await this._callOnStarts(request);
     } catch (err) {
@@ -119,7 +120,7 @@ export default class Client {
           )),
         ]);
 
-        let mutatedResponse = await this._callOnCompletes(request, response);
+        let mutatedResponse = await this._callOnCompletes(request, response, clonedRequest);
 
         if (mutatedResponse.status >= 400) {
           mutatedResponse = await this._callOnFails(request, mutatedResponse);

--- a/src/plugins/oauth.js
+++ b/src/plugins/oauth.js
@@ -21,7 +21,7 @@ export default {
     return request;
   },
 
-  async onComplete(request, response) {
+  async onComplete(request, response, clonedRequest) {
     const usedRefreshTokens = this.client.usedRefreshTokens;
     const currentRefreshToken = this.client.getRefreshToken();
 
@@ -53,7 +53,7 @@ export default {
         this.client.eventEmitter.emit(TOKEN_REFRESHED);
         const tokenRefreshResponseBody = await refreshResponse.json();
         await this.client.onRefreshResponse(tokenRefreshResponseBody);
-        return this.client.fetch(request);
+        return this.client.fetch(clonedRequest);
       }
       this.client.eventEmitter.emit(TOKEN_REFRESH_FAILED);
     }


### PR DESCRIPTION
#7335

updates client to always clone requests and pass the
cloned request on to the onComplete functions for plugins.

Couldn't figure out a better way that worked everywhere