### PR TITLE
Remove fetch-client events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ shippable/
 
 # package-lock.json should not be committed to library
 package-lock.json
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # fetch-client
 
-Wrapper for fetch that adds shortcuts, plugins and events. This is written and maintained by the fine folks at [Synapse Studios](http://www.synapsestudios.com). Our goal is to maintain the fetch api while adding in sensible defaults and hooks to request lifecycle events.
+Wrapper for fetch that adds shortcuts and plugins. This is written and maintained by the fine folks at [Synapse Studios](http://www.synapsestudios.com). Our goal is to maintain the fetch api while adding in sensible defaults.
 
-This library is inspired by libraries like [Fetch+](https://github.com/RickWong/fetch-plus) and [http-client](https://github.com/mjackson/http-client). There are differences in the details of how our plugins and events work.
+This library is inspired by libraries like [Fetch+](https://github.com/RickWong/fetch-plus) and [http-client](https://github.com/mjackson/http-client). There are differences in the details of how our plugins work.
 
 ## Installation
 
@@ -31,7 +31,7 @@ myClient.get('coolthings') // performs GET request to http://my-api.com/coolthin
 
 The client object provides these methods for making requests:
 
-- fetch(path, body, options) - wraps fetch and passes body options into the fetch call. Provides event/plugin features.
+- fetch(path, body, options) - wraps fetch and passes body options into the fetch call. Provides plugin features.
 - get(path, body, options)
 - post(path, body, options)
 - put(path, body, options)
@@ -82,17 +82,6 @@ By default fetch-client has a 10 second request time out. You can override that 
 
 If a request is exceeds the timeout time then the promise with be rejected with a `TimeoutError`. It's important to note that fetch requests can not be aborted, so just because your request timed out and the promise was rejected you should not assume that the request is not still pending.
 
-### Events
-
-Client objects will fire lifecycle events that your app can respond to.
-
-| Event Name      | Trigger Condition                                           | Args              |
-| --------------- | ----------------------------------------------------------- | ----------------- |
-| REQUEST_START   | Fires for every request before the request is even started. | Request           |
-| REQUEST_SUCCESS | Fires when a request returns an http status < 400           | Request, Response |
-| REQUEST_FAIL    | Fires when a request returns an http status >= 400          | Request, Response |
-| REQUEST_ERROR   | Fires when a request errors out. Server timeouts, etc       | Request, err      |
-
 #### Example
 
 ```
@@ -117,7 +106,7 @@ myClient.get('coolthings')
 
 ### Plugins
 
-Our plugin implementation allows you to register objects with async methods that will trigger during request lifecycle. Plugins are more robust than event callbacks because they have access to the event emitter, they are allowed to alter the Response object, and they can register their own helper methods on your client object. You can also return a Promise which will be resolved before the request lifecycle continues.
+Our plugin implementation allows you to register objects with async methods that will trigger during request lifecycle. Plugins are more robust than event callbacks because they are allowed to alter the Response object and they can register their own helper methods on your client object. You can also return a Promise which will be resolved before the request lifecycle continues.
 
 The most basic implementation of a plugin looks like this
 
@@ -148,8 +137,7 @@ This library includes some built-in plugins:
 
 ##### JWT
 
-The JWT plugin sets the JSON web token in the request's Authorization header and emits
-AUTH_EXPIRED or AUTH_FAILED events on 401 responses.
+The JWT plugin sets the JSON web token in the request's Authorization header.
 
 ```
 import { JwtPlugin } from '@synapsestudios/fetch-client';
@@ -209,29 +197,6 @@ class JsonResponsePlugin {
 myClient.addPlugin(new JsonResponsePlugin());
 myClient.get('coolthings').then(json => {
   // we have json now!
-});
-```
-
-#### Triggering Custom Events
-
-```
-class MyPlugin {
-  function onStart(request) {
-    // emit a custom event
-    this.client.eventEmitter.emit('custom_event', request);
-    return request;
-  }
-}
-
-myClient.addPlugin(new MyPlugin());
-
-// register a handler for our custom event
-myClient.on('custom_event', request => {
-  // do something
-});
-
-myClient.get('coolthings').then(response => {
-  // handle response
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@babel/runtime": "7.4.0",
-    "eventemitter2": "1.0.5",
     "merge": "1.2.0",
     "querystring": "0.2.0"
   }

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,3 @@
-import EventEmitter2 from 'eventemitter2';
-import * as events from './events';
 import PluginError from './plugin-error';
 import merge from 'merge';
 import { defaults as _defaults, allowedEncodings } from './defaults';
@@ -30,7 +28,6 @@ export default class Client {
         this.defaults.url[this.defaults.url.length - 1] === '/' ? '' : '/';
     }
 
-    this.eventEmitter = new EventEmitter2();
     this._plugins = [];
   }
 
@@ -111,7 +108,6 @@ export default class Client {
       request = this._getRequest(path, options);
     }
 
-    this.eventEmitter.emit(events.REQUEST_START, request);
     const clonedRequest = request.clone();
     try {
       request = await this._callOnStarts(request);
@@ -144,18 +140,8 @@ export default class Client {
 
         if (mutatedResponse.status >= 400) {
           mutatedResponse = await this._callOnFails(request, mutatedResponse);
-          this.eventEmitter.emit(
-            events.REQUEST_FAILURE,
-            request,
-            mutatedResponse
-          );
         } else {
           mutatedResponse = await this._callOnSuccesses(
-            request,
-            mutatedResponse
-          );
-          this.eventEmitter.emit(
-            events.REQUEST_SUCCESS,
             request,
             mutatedResponse
           );
@@ -164,7 +150,6 @@ export default class Client {
         return mutatedResponse;
       } catch (err) {
         const mutatedError = await this._callOnErrors(request, err);
-        this.eventEmitter.emit(events.REQUEST_ERROR, request, mutatedError);
         throw mutatedError;
       }
     }
@@ -189,10 +174,6 @@ export default class Client {
         i -= 1;
       }
     }
-  }
-
-  on(event, cb) {
-    this.eventEmitter.on(event, cb);
   }
 
   /* ---- HELPERS ---- */

--- a/src/plugins/jwt.js
+++ b/src/plugins/jwt.js
@@ -1,25 +1,3 @@
-import { AUTH_EXPIRED, AUTH_FAILED } from '../events';
-
-const isExpired = (token) => {
-  try {
-    const tokenPayload = token.substring(
-      token.indexOf('.') + 1,
-      token.indexOf('.', token.indexOf('.') + 1)
-    );
-
-    const decodedPayload = JSON.parse(atob(tokenPayload));
-
-    if (decodedPayload.exp < new Date().getTime() / 1000) {
-      return true;
-    }
-  } catch (error) {
-    // Swallow any JSON or base64 decoding errors
-    return false;
-  }
-
-  return false;
-};
-
 class JwtPlugin {
   constructor() {
     this.helpers = {
@@ -41,17 +19,6 @@ class JwtPlugin {
       request.headers.append('Authorization', jwtToken);
     }
     return request;
-  }
-
-  onFail(request, response) {
-    if (response.status === 401) {
-      if (isExpired(this.client.getJwtToken())) {
-        this.client.eventEmitter.emit(AUTH_EXPIRED, request, response);
-      } else {
-        this.client.eventEmitter.emit(AUTH_FAILED, request, response);
-      }
-    }
-    return response;
   }
 }
 

--- a/src/plugins/oauth.js
+++ b/src/plugins/oauth.js
@@ -1,64 +1,42 @@
 import qs from 'querystring';
-import events from 'events';
-
-const TOKEN_REFRESHED = 'TOKEN_REFRESHED';
-const TOKEN_REFRESH_FAILED = 'TOKEN_REFRESH_FAILED';
-
-const emitter = new events.EventEmitter()
 
 export default {
   async onStart(request) {
-    if (this.client.refreshing) {
-      request.secondTry = true;
+    if (this.client.refreshing) await this.client.refreshPromise;
 
-      await new Promise(resolve => {
-        emitter.once(TOKEN_REFRESHED, () => {
-          request.headers.set('Authorization', `Bearer ${this.client.getBearerToken()}`);
-          resolve();
-        });
-        emitter.once(TOKEN_REFRESH_FAILED, () => resolve());
-      });
-    } else {
-      request.headers.set('Authorization', `Bearer ${this.client.getBearerToken()}`);
-    }
+    request.headers.set(
+      'Authorization',
+      `Bearer ${this.client.getBearerToken()}`
+    );
+
     return request;
   },
 
   async onComplete(request, response, clonedRequest) {
-    const usedRefreshTokens = this.client.usedRefreshTokens;
-    const currentRefreshToken = this.client.getRefreshToken();
+    if (response.status === 401) {
+      if (!this.client.refreshing) {
+        const refreshToken = this.client.getRefreshToken();
 
-    if (this.client.refreshing) {
-      const refreshResponse = await this.client.refreshPromise;
-      if (refreshResponse.status === 200) {
-        return this.client.fetch(clonedRequest);
+        this.client.refreshing = true;
+
+        this.client.refreshPromise = this.helpers
+          .refreshToken(this.client.oauthConfig, refreshToken)
+          .then(async (response) => {
+            if (response.status === 200) {
+              this.client.usedRefreshTokens.push(refreshToken);
+              const json = await response.json();
+              await this.client.onRefreshResponse(json);
+            }
+            this.client.refreshing = false;
+            return response;
+          });
       }
-    }
-
-    if (
-      !this.client.refreshing &&
-      response.status === 401 &&
-      !usedRefreshTokens.includes(currentRefreshToken)
-    ) {
-      this.client.refreshing = true;
-
-      this.client.refreshPromise = this.helpers.refreshToken(
-        this.client.oauthConfig,
-        this.client.getRefreshToken
-      );
 
       const refreshResponse = await this.client.refreshPromise;
 
-      this.client.refreshing = false;
-
       if (refreshResponse.status === 200) {
-        this.client.usedRefreshTokens.push(currentRefreshToken);
-        emitter.emit(TOKEN_REFRESHED);
-        const tokenRefreshResponseBody = await refreshResponse.json();
-        await this.client.onRefreshResponse(tokenRefreshResponseBody);
         return this.client.fetch(clonedRequest);
       }
-      emitter.emit(TOKEN_REFRESH_FAILED);
     }
 
     return response;
@@ -69,7 +47,7 @@ export default {
       this.oauthConfig = config;
     },
 
-    refreshToken(oauthConfig, getRefreshToken) {
+    refreshToken(oauthConfig, refreshToken) {
       const tokenRequest = new Request(oauthConfig.refresh_path, {
         method: 'POST',
         headers: {
@@ -77,7 +55,7 @@ export default {
         },
         body: qs.stringify({
           grant_type: 'refresh_token',
-          refresh_token: getRefreshToken(),
+          refresh_token: refreshToken,
           client_id: oauthConfig.client_id,
         }),
       });

--- a/src/plugins/oauth.js
+++ b/src/plugins/oauth.js
@@ -2,7 +2,7 @@ import qs from 'querystring';
 
 export default {
   async onStart(request) {
-    if (this.client.refreshing) await this.client.refreshPromise;
+    if (this.client.refreshing) await this.client.refreshRequest;
 
     request.headers.set(
       'Authorization',
@@ -15,11 +15,11 @@ export default {
   async onComplete(request, response, clonedRequest) {
     if (response.status === 401) {
       if (!this.client.refreshing) {
-        const refreshToken = this.client.getRefreshToken();
-
         this.client.refreshing = true;
 
-        this.client.refreshPromise = this.helpers
+        const refreshToken = this.client.getRefreshToken();
+
+        this.client.refreshRequest = this.helpers
           .refreshToken(this.client.oauthConfig, refreshToken)
           .then(async (response) => {
             if (response.status === 200) {
@@ -32,9 +32,9 @@ export default {
           });
       }
 
-      const refreshResponse = await this.client.refreshPromise;
+      const response = await this.client.refreshRequest;
 
-      if (refreshResponse.status === 200) {
+      if (response.status === 200) {
         return this.client.fetch(clonedRequest);
       }
     }

--- a/test/plugins/jwt-test.js
+++ b/test/plugins/jwt-test.js
@@ -11,7 +11,6 @@ chai.use(sinonChai);
 
 import Client from '../../src/client';
 import JwtPlugin from '../../src/plugins/jwt';
-import { AUTH_EXPIRED, AUTH_FAILED } from '../../src/events';
 
 // polyfills
 import { Request, Response } from 'whatwg-fetch';
@@ -77,109 +76,6 @@ describe('jwt-plugin', () => {
 
     return expect(client.post(request)).to.be.fulfilled.then((resolution) => {
       expect(resolution).to.equal(response);
-    });
-  });
-
-  it('emits AUTH_EXPIRED event if request 401s and token is expired', () => {
-    const response = new Response("{ body: 'content' }", { status: 401 });
-    global.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = getToken({ exp: 1 });
-    const request = new Request();
-    const client = new Client();
-    const failedSpy = sinon.spy();
-    const expiredSpy = sinon.spy();
-    client.on(AUTH_EXPIRED, expiredSpy);
-    client.on(AUTH_FAILED, failedSpy);
-    client.addPlugin(jwtPlugin);
-    client.setJwtTokenGetter(() => token);
-
-    return client.post(request).then(() => {
-      expect(failedSpy).to.not.have.been.called;
-      expect(expiredSpy).to.have.been.called;
-      expect(expiredSpy.args[0][0]).to.equal(request);
-      expect(expiredSpy.args[0][1]).to.equal(response);
-    });
-  });
-
-  it('emits AUTH_FAILED event if request 401s but token is not expired', () => {
-    const response = new Response("{ body: 'content' }", { status: 401 });
-    global.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = getToken({ exp: new Date().getTime() / 1000 + 1000 });
-    const request = new Request();
-    const client = new Client();
-    const failedSpy = sinon.spy();
-    const expiredSpy = sinon.spy();
-    client.on(AUTH_EXPIRED, expiredSpy);
-    client.on(AUTH_FAILED, failedSpy);
-    client.addPlugin(jwtPlugin);
-    client.setJwtTokenGetter(() => token);
-
-    return client.post(request).then(() => {
-      expect(failedSpy).to.have.been.called;
-      expect(expiredSpy).not.to.have.been.called;
-      expect(failedSpy.args[0][0]).to.equal(request);
-      expect(failedSpy.args[0][1]).to.equal(response);
-    });
-  });
-
-  it('emits AUTH_FAILED event if request 401s and token is null', () => {
-    const response = new Response("{ body: 'content' }", { status: 401 });
-    global.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = null;
-    const request = new Request();
-    const client = new Client();
-    const failedSpy = sinon.spy();
-    const expiredSpy = sinon.spy();
-    client.on(AUTH_EXPIRED, expiredSpy);
-    client.on(AUTH_FAILED, failedSpy);
-    client.addPlugin(jwtPlugin);
-    client.setJwtTokenGetter(() => token);
-
-    return client.post(request).then(() => {
-      expect(failedSpy).to.have.been.called;
-      expect(expiredSpy).not.to.have.been.called;
-      expect(failedSpy.args[0][0]).to.equal(request);
-      expect(failedSpy.args[0][1]).to.equal(response);
-    });
-  });
-
-  it('emits AUTH_FAILED event if request 401s and decoded token is invalid JSON', () => {
-    const response = new Response("{ body: 'content' }", { status: 401 });
-    global.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = 'foo';
-    const request = new Request();
-    const client = new Client();
-    const failedSpy = sinon.spy();
-    const expiredSpy = sinon.spy();
-    client.on(AUTH_EXPIRED, expiredSpy);
-    client.on(AUTH_FAILED, failedSpy);
-    client.addPlugin(jwtPlugin);
-    client.setJwtTokenGetter(() => token);
-
-    return client.post(request).then(() => {
-      expect(failedSpy).to.have.been.called;
-      expect(expiredSpy).not.to.have.been.called;
-      expect(failedSpy.args[0][0]).to.equal(request);
-      expect(failedSpy.args[0][1]).to.equal(response);
-    });
-  });
-
-  it('does not emit either custom event if request fails with non-401', () => {
-    const response = new Response("{ body: 'content' }", { status: 500 });
-    global.fetch = sinon.spy(() => Promise.resolve(response));
-    const token = getToken({ exp: new Date().getTime() / 1000 + 1000 });
-    const request = new Request();
-    const client = new Client();
-    const failedSpy = sinon.spy();
-    const expiredSpy = sinon.spy();
-    client.on(AUTH_EXPIRED, expiredSpy);
-    client.on(AUTH_FAILED, failedSpy);
-    client.addPlugin(jwtPlugin);
-    client.setJwtTokenGetter(() => token);
-
-    return client.post(request).then(() => {
-      expect(failedSpy).not.to.have.been.called;
-      expect(expiredSpy).not.to.have.been.called;
     });
   });
 });

--- a/test/plugins/oauth-test.js
+++ b/test/plugins/oauth-test.js
@@ -201,8 +201,8 @@ describe('oauth-plugin', () => {
       expect(global.fetch.callCount).to.equal(3);
       expect(oauthPlugin.helpers.refreshToken).to.be.calledOnce;
       // requests resolve to the response object
-      expect(resolutions[0]).to.equal(response200ii); // Not sure why this one is first but it's fine
-      expect(resolutions[1]).to.equal(response200);
+      expect(resolutions[0]).to.equal(response200);
+      expect(resolutions[1]).to.equal(response200ii);
     });
   });
 


### PR DESCRIPTION
Pretty much everything was just a matter of stripping out events.

The only thing I actually had to change was the oauth plugin implementation, since the refresh logic used events. It now just uses a promise.